### PR TITLE
Support Strong Customer Authentication (SCA)

### DIFF
--- a/oauth2.py
+++ b/oauth2.py
@@ -27,6 +27,7 @@ class OAuth2Client:
     '''
     
     def __init__(self):
+        self._user_id = ""
         self._is_confidential_client = config.MONZO_CLIENT_IS_CONFIDENTIAL
         # Your client should only be confidential if it is a backend application, with
         # OAuth secret hidden from the user.
@@ -104,6 +105,10 @@ class OAuth2Client:
                 if config.MONZO_CLIENT_IS_CONFIDENTIAL:
                     print("Warning: this client is not registered as confidential, we will not be able to refresh token")
     
+            if "user_id" not in response_object:
+                error("Could not retrieve user_id from token exchange response: {}", response_object)
+            self._user_id = response_object["user_id"]
+
 
     def refresh_access_token(self):
         ''' If we are a confidential client, we can refresh the access token to get a new one derived from the same OAuth


### PR DESCRIPTION
During the authentication flow, it is now necessary to wait for the user to confirm access of this third-party app in their Monzo app, before the reference app can load transactions. To support SCA, we simply need to wait on a prompt.

Also fixes an issue where the reference app would have tried to attach receipts to transactions not initiated by the user (e.g. Monzo Plus subscription fees, overdraft fees), if it happens to be the latest transaction. This would have failed (similar to https://github.com/monzo/reference-receipts-app/issues/1).